### PR TITLE
Fix custom payment method & return message

### DIFF
--- a/android/src/main/java/snail/app/flutter/google/pay/FlutterGooglePayPlugin.java
+++ b/android/src/main/java/snail/app/flutter/google/pay/FlutterGooglePayPlugin.java
@@ -112,21 +112,13 @@ public class FlutterGooglePayPlugin implements MethodCallHandler, PluginRegistry
      * Data</a>
      */
     private void callToDartOnPaymentSuccess(PaymentData paymentData) {
-        JSONObject paymentMethodData = null;
-        try {
-            if (paymentData.getPaymentMethodToken() != null) {
-                paymentMethodData = new JSONObject(paymentData.getPaymentMethodToken().getToken());
-            }
-            Log.d("PaymentData:", String.valueOf(paymentMethodData));
-            Map<String, Object> data = new HashMap<>();
-            data.put("status", paymentMethodData != null ? "SUCCESS" : "UNKNOWN");
-            if (paymentMethodData != null) {
-                data.put("result", paymentMethodData.toString());
-            }
-            mLastResult.success(data);
-        } catch (JSONException e) {
-            this.callToDartOnError(e.getMessage());
+        String paymentInfo = paymentData.toJson();
+        Map<String, Object> data = new HashMap<>();
+        data.put("status", paymentInfo != null ? "SUCCESS" : "UNKNOWN");
+        if (paymentInfo != null) {
+            data.put("result", paymentInfo);
         }
+        mLastResult.success(data);
     }
 
     private void callToDartOnGooglePayIsAvailable(boolean isAvailable) {

--- a/android/src/main/java/snail/app/flutter/google/pay/FlutterGooglePayPlugin.java
+++ b/android/src/main/java/snail/app/flutter/google/pay/FlutterGooglePayPlugin.java
@@ -202,9 +202,8 @@ public class FlutterGooglePayPlugin implements MethodCallHandler, PluginRegistry
     }
 
     private void requestPaymentCustom() {
-        Map map = mLastMethodCall.argument("custom_data");
         try {
-            JSONObject paymentData = new JSONObject(map);
+            JSONObject paymentData = new JSONObject((Map)mLastMethodCall.arguments);
             PaymentDataRequest request =
                     PaymentDataRequest.fromJson(paymentData.toString());
             this.makePayment(request);


### PR DESCRIPTION
Hi,

Ive put a fix in for custom payment methods, and updated the response handler to follow latest docs.

`getPaymentMethodToken` was deprecated.

